### PR TITLE
Feature/lbg/issue obdeploy 606

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 |---|---|
 |Build|[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FOpenBankingToolkit%2Fopenbanking-uk-extensions%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/OpenBankingToolkit/openbanking-uk-extensions/goto?ref=master)|
 |Code coverage|[![codecov](https://codecov.io/gh/OpenBankingToolKit/openbanking-uk-extensions/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenBankingToolkit/openbanking-uk-extensions)
-|Bintray|[![Bintray](https://img.shields.io/bintray/v/openbanking-toolkit/OpenBankingToolKit/openbanking-uk-extensions.svg)](https://bintray.com/openbanking-toolkit/OpenBankingToolKit/openbanking-uk-extensions)|
+|Github|[![GitHub release (latest by date)](https://img.shields.io/github/v/release/OpenBankingToolkit/openbanking-uk-extensions.svg)](https://img.shields.io/github/v/release/OpenBankingToolkit/openbanking-uk-extensions)
 |License|![license](https://img.shields.io/github/license/ACRA/acra.svg)|
 
 ForgeRock OpenBanking Extensions

--- a/forgerock-openbanking-uk-extensions/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/factory/CSVFilePaymentType.java
+++ b/forgerock-openbanking-uk-extensions/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/factory/CSVFilePaymentType.java
@@ -23,6 +23,8 @@ package com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.exception.CSVErrorException;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.exception.CSVErrorType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.util.MimeType;
 
 import java.util.Arrays;
 
@@ -43,7 +45,7 @@ public enum CSVFilePaymentType {
     }
 
     public String getContentType() {
-        return "text/csv";
+        return MediaType.TEXT_PLAIN_VALUE;
     }
 
     public boolean isSupported(String fileType) {


### PR DESCRIPTION
**CSV File payments Feature**
- Updated the contentType for CSV File payments to `text/plain` instead of `text/csv`.
- Update the release badge from bintray to Github.
