### PR TITLE
Release/1.0.16 (Fix missing analytics entries use 1.0.41 of ob clients)

### DIFF
--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.0.16-SNAPSHOT</version>
+        <version>1.0.16</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.17-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.0.16</version>
+    <version>1.0.17-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -121,7 +121,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>1.0.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.0.16-SNAPSHOT</version>
+    <version>1.0.16</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -121,7 +121,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>HEAD</tag>
+        <tag>1.0.16</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <ob-aspsp.version>1.0.102</ob-aspsp.version>
         <ob-common.version>1.0.81</ob-common.version>
-        <ob-clients.version>1.0.40</ob-clients.version>
+        <ob-clients.version>1.0.41</ob-clients.version>
         <!-- others -->
         <commons-csv.version>1.7</commons-csv.version>
         <springboot-test.version>2.1.5.RELEASE</springboot-test.version>


### PR DESCRIPTION
**Features and Fixes**
- Bumped [Openbanking-clients](https://github.com/OpenBankingToolkit/openbanking-clients) release [version 1.0.41](https://github.com/OpenBankingToolkit/openbanking-clients/releases/tag/1.0.41)
   - Fix analytics empty entries [163](https://github.com/OpenBankingToolkit/openbanking-analytics/issues/163)