### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <ob-aspsp.version>1.5.0</ob-aspsp.version>
-        <ob-common.version>1.2.5</ob-common.version>
-        <ob-clients.version>1.2.4</ob-clients.version>
+        <ob-aspsp.version>1.5.1</ob-aspsp.version>
+        <ob-common.version>1.2.9</ob-common.version>
+        <ob-clients.version>1.2.9</ob-clients.version>
         <!-- others -->
         <commons-csv.version>1.7</commons-csv.version>
         <springboot-test.version>2.1.5.RELEASE</springboot-test.version>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140