### PR TITLE
Release 1.5.2 with 796: Add MATLS checks to DCR code

### DIFF
--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.5.2-SNAPSHOT</version>
+        <version>1.5.2</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.3-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <ob-aspsp.version>1.5.1</ob-aspsp.version>
-        <ob-common.version>1.2.9</ob-common.version>
-        <ob-clients.version>1.2.9</ob-clients.version>
+        <ob-aspsp.version>1.5.2</ob-aspsp.version>
+        <ob-common.version>1.2.11</ob-common.version>
+        <ob-clients.version>1.2.11</ob-clients.version>
         <!-- others -->
         <commons-csv.version>1.7</commons-csv.version>
         <springboot-test.version>2.1.5.RELEASE</springboot-test.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>1.5.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.5.2</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.2</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796