### PR TITLE
45: Use fixed uk-datamodel for 3.1.8 and latest aspsp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <ob-aspsp.version>1.5.5</ob-aspsp.version>
-        <ob-common.version>1.2.12</ob-common.version>
-        <ob-clients.version>1.2.12</ob-clients.version>
+        <ob-aspsp.version>1.5.6</ob-aspsp.version>
+        <ob-common.version>1.2.14</ob-common.version>
+        <ob-clients.version>1.2.14</ob-clients.version>
         <!-- others -->
         <commons-csv.version>1.7</commons-csv.version>
         <springboot-test.version>2.1.5.RELEASE</springboot-test.version>


### PR DESCRIPTION
OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45