### PR TITLE
Release 1.5.6 to use fixed uk-datamodel for 3.1.8r5 model and aspsp

### DIFF
--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.7-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.5.6-SNAPSHOT</version>
+        <version>1.5.6</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>1.5.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.5.6-SNAPSHOT</version>
+    <version>1.5.6</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>HEAD</tag>
+        <tag>1.5.6</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
45: Use fixed uk-datamodel for 3.1.8 and apspsp

OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45