### PR TITLE
831: Use latest aspsp with fix for /data/user api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <ob-aspsp.version>1.7.0</ob-aspsp.version>
+        <ob-aspsp.version>1.7.1</ob-aspsp.version>
         <ob-common.version>1.3.3</ob-common.version>
         <ob-clients.version>1.3.2</ob-clients.version>
         <!-- others -->


### PR DESCRIPTION
Fixes the /user/data api issues;
This api now supports true MATLS in that you must provide a Bearer access token when using the /data/user apis.
The user is identified from the obri-session cookie in the request, while the Bearer Access Token is used to ensure that the TPP making the request is onboarded. The access_token must have been issued to an OpenID client that belongs to the same organisation as the MATLS OBWac certificate used to create the TLS connection over with the request is sent.
The apis now create/delete Customer Info etc.
So, this completes https://github.com/ForgeCloud/ob-deploy/issues/815
And contains the full fix for https://github.com/ForgeCloud/ob-deploy/issues/831

Issue: https://github.com/ForgeCloud/ob-deploy/issues/831