### PR TITLE
965: Accept new OpenBanking SSAs and release v1.8.4

### DIFF
--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.8.4-SNAPSHOT</version>
+        <version>1.8.4</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-uk-extensions/pom.xml
+++ b/forgerock-openbanking-uk-extensions/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>openbanking-uk-extensions</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.5-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <ob-aspsp.version>2.1.3</ob-aspsp.version>
-        <ob-common.version>1.5.2</ob-common.version>
-        <ob-clients.version>1.5.2</ob-clients.version>
+        <ob-aspsp.version>2.1.4</ob-aspsp.version>
+        <ob-common.version>1.5.3</ob-common.version>
+        <ob-clients.version>1.5.3</ob-clients.version>
         <!-- others -->
         <commons-csv.version>1.7</commons-csv.version>
         <springboot-test.version>2.1.5.RELEASE</springboot-test.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.8.4-SNAPSHOT</version>
+    <version>1.8.4</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>HEAD</tag>
+        <tag>1.8.4</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>ForgeRock OpenBanking uk Extensions</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>openbanking-uk-extensions</artifactId>
-    <version>1.8.4</version>
+    <version>1.8.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         A Java library to extend the Openbanking UK SDK
@@ -120,7 +120,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-extensions.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-extensions.git</url>
-        <tag>1.8.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Open Banking SSAs have software_version as a string rather than a double

Issue: https://github.com/forgecloud/ob-deploy/issues/965